### PR TITLE
_changesテーブル用の共通処理をまとめたmoduleを作成

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,7 @@ jobs:
 
       # Database setup
       - run: bundle exec rake db:create
-      # Todo: Migrationファイルが作られたタイミングでコメントアウトを外す
-      # - run: bundle exec rake db:schema:load
+      - run: bundle exec rake db:schema:load
 
       # Todo: テストを記述後にコメントアウトを外す
       # run tests!

--- a/app/models/concerns/creatable_from_original.rb
+++ b/app/models/concerns/creatable_from_original.rb
@@ -1,0 +1,26 @@
+# _changes用のModule
+# originalのレコードを元に履歴を生成するメソッドを付加するModule
+# includeする_changesテーブル用のModelには必ずORIGINAL_FOREIGN_KEYを定義して、FKをシンボルで格納すること。
+module CreatableFromOriginal
+  extend ActiveSupport::Concern
+
+  CHANGES_EVENT_TYPES = ['create', 'update', 'delete']
+
+  included do
+    validates :event, presence: true, inclusion: { in: CHANGES_EVENT_TYPES }
+  end
+
+  module ClassMethods
+    # Originalのレコードを元に変更履歴を生成
+    # @param  [ApplicationRecord] original_record
+    # @param  [String] event
+    # @return [ApplicationRecord]
+    def create_from_original!(original_record:, event:)
+      create!(
+        original_record.attributes
+                .except("id", "created_at", "updated_at")
+                .merge(self::ORIGINAL_FOREIGN_KEY => original_record.id, event: event)
+      )
+    end
+  end
+end

--- a/app/models/user_change.rb
+++ b/app/models/user_change.rb
@@ -12,5 +12,8 @@
 #
 
 class UserChange < ApplicationRecord
-  validates :event, presence: true
+  include CreatableFromOriginal
+  ORIGINAL_FOREIGN_KEY = :user_id
+
+  belongs_to :user
 end

--- a/app/models/user_profile_change.rb
+++ b/app/models/user_profile_change.rb
@@ -15,5 +15,8 @@
 #
 
 class UserProfileChange < ApplicationRecord
-  validates :event, presence: true
+  include CreatableFromOriginal
+  ORIGINAL_FOREIGN_KEY = :user_profile_id
+
+  belongs_to :user_profile
 end


### PR DESCRIPTION
## 実装内容
- _changesテーブル用の共通処理をまとめたmoduleを作成(creatable_from_original.rb)
  - originalのレコードのインスタンスからコピーを作成するメソッド
  - 以下のvalidationを自動でinclude
    - eventカラムの存在チェック
    - eventカラムに入る文字チェック
- 既存のchangesテーブルにCreatableFromOriginalをincludeして利用できるように改修

## 備考
今後、changesテーブルにはこのCreatableFromOriginalモジュールをincludeして
originalのテーブルからのコピー処理は共通化する。
パッと作っただけでうまくいくかは微妙なので、改善の余地があれば日々修正する予定。
