### PR TITLE
changesテーブルを有するテーブル用のModuleを作成

### DIFF
--- a/app/models/concerns/creatable_from_original.rb
+++ b/app/models/concerns/creatable_from_original.rb
@@ -4,10 +4,10 @@
 module CreatableFromOriginal
   extend ActiveSupport::Concern
 
-  CHANGES_EVENT_TYPES = ['create', 'update', 'delete']
+  CHANGES_EVENT_TYPES = ["create", "update", "delete"]
 
   included do
-    validates :event, presence: true, inclusion: { in: CHANGES_EVENT_TYPES }
+    validates :event, presence: true, inclusion: {in: CHANGES_EVENT_TYPES}
   end
 
   module ClassMethods
@@ -18,8 +18,8 @@ module CreatableFromOriginal
     def create_from_original!(original_record:, event:)
       create!(
         original_record.attributes
-                .except("id", "created_at", "updated_at")
-                .merge(self::ORIGINAL_FOREIGN_KEY => original_record.id, event: event)
+          .except("id", "created_at", "updated_at")
+          .merge(self::ORIGINAL_FOREIGN_KEY => original_record.id, event: event)
       )
     end
   end

--- a/app/models/concerns/performable_with_changes.rb
+++ b/app/models/concerns/performable_with_changes.rb
@@ -1,0 +1,60 @@
+# Changesテーブルを有するOriginalテーブル用のModule
+# 登録・更新・削除処理それぞれにchangesテーブルの保存処理を付加したメソッドが定義されている。
+# Changesテーブルを有するテーブルは原則として本Moduleに定義されているメソッドを使う必要がある。
+#
+# テスト(RSpec)について
+# 本テストをIncludeしたクラスのテストには必ず~/spec/support/performable_with_changes_manager.rbの
+# shared_contextをincludeすること。
+# performable_with_changes_manager.rbの方に本モジュールのテストが全て記載されているため、
+# 個別にテストを追記していく必要はない。
+module PerformableWithChanges
+  extend ActiveSupport::Concern
+
+  # レコードを保存して、Changesテーブルを登録するメソッド
+  def save_with_changes!
+    ActiveRecord::Base.transaction do
+      save!
+      self.class.send(:create_from_original!, original_record: self, event: "create")
+      self
+    end
+  end
+
+  # レコードを更新して、Changesテーブルを登録するメソッド
+  def update_with_changes!(attributes)
+    ActiveRecord::Base.transaction do
+      update!(attributes)
+      self.class.send(:create_from_original!, original_record: self, event: "update")
+      self
+    end
+  end
+
+  # レコードを削除して、Changesテーブルを登録するメソッド
+  def destroy_with_changes!
+    ActiveRecord::Base.transaction do
+      self.class.send(:create_from_original!, original_record: self, event: "delete")
+      destroy!
+    end
+  end
+
+  module ClassMethods
+    # レコードを登録して、Changesテーブルを登録するメソッド
+    def create_with_changes!(attributes)
+      ActiveRecord::Base.transaction do
+        instance = create!(attributes)
+        create_from_original!(original_record: instance, event: "create")
+        instance
+      end
+    end
+
+    private
+
+    # includeしたモデルのChangeテーブルへの保存処理を実行するメソッド
+    # evalを利用していることもあり、外部から利用されたくないので、privateにしている。
+    def create_from_original!(original_record:, event:)
+      eval("#{self}Change", binding, __FILE__, __LINE__).create_from_original!(
+        original_record: original_record,
+        event: event,
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@
 #
 
 class User < ApplicationRecord
+  include PerformableWithChanges
+
   has_secure_password
   has_one :profile, dependent: :destroy, class_name: "UserProfile"
   has_one :provisional_user_completed_log, dependent: :destroy
@@ -32,30 +34,11 @@ class User < ApplicationRecord
   # 稼働中のアカウント(未凍結 & 退会していない)
   scope :active, -> { unfreezed.unresigned }
 
-  # ユーザーデータを更新して、changesテーブルを作成するメソッド
-  # TODO(Shokei Takanashi) : changesテーブルを有する全Modelにこのメソッドが書かれるのは単調なので、あとでModule化する。
-  def update_with_changes!(attributes)
-    ActiveRecord::Base.transaction do
-      update!(attributes)
-      UserChange.create_from_original!(original_record: self, event: "update")
-      self
-    end
-  end
-
   class << self
-    # 会員テーブルをchangesテーブルとともに作成するメソッド
-    def create_with_changes!(email:, password_digest:)
-      ActiveRecord::Base.transaction do
-        user = create!(email: email, password_digest: password_digest)
-        UserChange.create_from_original!(original_record: user, event: "create")
-        user
-      end
-    end
-
     # 会員登録を完了させるメソッド
     def complete_member_registration!(provisional_user)
       ActiveRecord::Base.transaction do
-        user = create_with_changes!(email: provisional_user.email, password_digest: provisional_user.password_digest)
+        user = create_with_changes!({email: provisional_user.email, password_digest: provisional_user.password_digest})
 
         # usersテーブルとprovisional_usersテーブルの結び付き関係を格納する
         ProvisionalUserCompletedLog.create!(user_id: user.id, provisional_user_id: provisional_user.id)

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -15,11 +15,13 @@
 #
 
 class UserProfile < ApplicationRecord
+  include PerformableWithChanges
+
   belongs_to :user
-  validates :last_name, presence: true, length: { maximum: 20 }
-  validates :last_name_kana, presence: true, length: { maximum: 30 }
-  validates :first_name, presence: true, length: { maximum: 20 }
-  validates :first_name_kana, presence: true, length: { maximum: 30 }
+  validates :last_name, presence: true, length: {maximum: 20}
+  validates :last_name_kana, presence: true, length: {maximum: 30}
+  validates :first_name, presence: true, length: {maximum: 20}
+  validates :first_name_kana, presence: true, length: {maximum: 30}
   validates :birth_on, presence: true
   validates :job, presence: true
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -11,24 +11,12 @@
 #
 
 class Word < ApplicationRecord
+  include PerformableWithChanges
+
   belongs_to :user
 
   validates :user_id, presence: true
   validates :name, presence: true
   validates :phonetic, presence: true
   validates :description, presence: true
-
-  def save_with_changes!
-    ActiveRecord::Base.transaction do
-      save!
-      WordChange.create_from_original!(original_record: self, event: "create")
-    end
-  end
-
-  def destroy_with_changes!
-    ActiveRecord::Base.transaction do
-      WordChange.create_from_original!(original_record: self, event: "delete")
-      destroy!
-    end
-  end
 end

--- a/db/migrate/20180715034647_create_user_profile_changes.rb
+++ b/db/migrate/20180715034647_create_user_profile_changes.rb
@@ -2,6 +2,7 @@ class CreateUserProfileChanges < ActiveRecord::Migration[5.2]
   def change
     create_table :user_profile_changes, comment: "ユーザープロフィール更新履歴" do |t|
       t.bigint :user_profile_id, null: false, comment: "ユーザープロフィールID"
+      t.bigint :user_id, null: false, comment: "ユーザーID"
       t.string :last_name, null: false, comment: "苗字"
       t.string :last_name_kana, null: false, comment: "苗字(フリガナ)"
       t.string :first_name, null: false, comment: "名前"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,12 +20,10 @@ ActiveRecord::Schema.define(version: 2018_08_14_115515) do
   end
 
   create_table "favorite_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "お気に入りが外された時の履歴", force: :cascade do |t|
-    t.bigint "user_id", null: false, comment: "ユーザーID(FK)"
-    t.bigint "word_id", null: false, comment: "言葉ID(FK)"
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.bigint "word_id", null: false, comment: "言葉ID"
     t.string "event", null: false, comment: "イベント"
     t.datetime "created_at", null: false
-    t.index ["user_id"], name: "index_favorite_changes_on_user_id"
-    t.index ["word_id"], name: "index_favorite_changes_on_word_id"
   end
 
   create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "お気に入り", force: :cascade do |t|
@@ -134,15 +132,13 @@ ActiveRecord::Schema.define(version: 2018_08_14_115515) do
   end
 
   create_table "word_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "投稿が削除された時の履歴", force: :cascade do |t|
-    t.bigint "user_id", null: false, comment: "ユーザーID(FK)"
-    t.bigint "word_id", null: false, comment: "言葉ID(FK)"
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.bigint "word_id", null: false, comment: "言葉ID"
     t.string "name", null: false, comment: "名前"
     t.string "phonetic", null: false, comment: "ふりがな"
     t.string "description", null: false, comment: "説明"
     t.string "event", null: false, comment: "イベント"
     t.datetime "created_at", null: false
-    t.index ["user_id"], name: "index_word_changes_on_user_id"
-    t.index ["word_id"], name: "index_word_changes_on_word_id"
   end
 
   create_table "words", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "言葉", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2018_08_14_115515) do
 
   create_table "user_profile_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "ユーザープロフィール更新履歴", force: :cascade do |t|
     t.bigint "user_profile_id", null: false, comment: "ユーザープロフィールID"
+    t.bigint "user_id", null: false, comment: "ユーザーID"
     t.string "last_name", null: false, comment: "苗字"
     t.string "last_name_kana", null: false, comment: "苗字(フリガナ)"
     t.string "first_name", null: false, comment: "名前"

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,23 +1,27 @@
 # == Schema Information
 #
-# Table name: user_profile_changes # ユーザープロフィール更新履歴
+# Table name: user_profiles # ユーザープロフィール情報
 #
 #  id              :bigint(8)        not null, primary key
-#  user_profile_id :bigint(8)        not null              # ユーザープロフィールID
-#  user_id         :bigint(8)        not null              # ユーザーID
+#  user_id         :bigint(8)        not null              # ユーザーID(FK)
 #  last_name       :string(255)      not null              # 苗字
 #  last_name_kana  :string(255)      not null              # 苗字(フリガナ)
 #  first_name      :string(255)      not null              # 名前
 #  first_name_kana :string(255)      not null              # 名前(フリガナ)
 #  birth_on        :date             not null              # 生年月日
 #  job             :string(255)      not null              # 職業
-#  event           :string(255)      not null              # イベント
 #  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 
-class UserProfileChange < ApplicationRecord
-  include CreatableFromOriginal
-  ORIGINAL_FOREIGN_KEY = :user_profile_id
-
-  belongs_to :user_profile
+FactoryBot.define do
+  factory :user_profile do
+    last_name "string"
+    last_name_kana "string"
+    first_name "string"
+    first_name_kana "string"
+    birth_on 15.years.ago
+    job "string"
+    association :user
+  end
 end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -1,23 +1,22 @@
 # == Schema Information
 #
-# Table name: user_profile_changes # ユーザープロフィール更新履歴
+# Table name: user_profiles # ユーザープロフィール情報
 #
 #  id              :bigint(8)        not null, primary key
-#  user_profile_id :bigint(8)        not null              # ユーザープロフィールID
-#  user_id         :bigint(8)        not null              # ユーザーID
+#  user_id         :bigint(8)        not null              # ユーザーID(FK)
 #  last_name       :string(255)      not null              # 苗字
 #  last_name_kana  :string(255)      not null              # 苗字(フリガナ)
 #  first_name      :string(255)      not null              # 名前
 #  first_name_kana :string(255)      not null              # 名前(フリガナ)
 #  birth_on        :date             not null              # 生年月日
 #  job             :string(255)      not null              # 職業
-#  event           :string(255)      not null              # イベント
 #  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 
-class UserProfileChange < ApplicationRecord
-  include CreatableFromOriginal
-  ORIGINAL_FOREIGN_KEY = :user_profile_id
 
-  belongs_to :user_profile
+require "rails_helper"
+
+RSpec.describe UserProfile, type: :model do
+  include_context 'Changesテーブルを有する場合', UserProfile
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: users # ユーザー情報
+#
+#  id              :bigint(8)        not null, primary key
+#  email           :string(255)      not null                        # メールアドレス
+#  password_digest :string(255)      not null                        # パスワード
+#  freezed         :boolean          default("unfreezed"), not null  # 凍結状態
+#  resigned        :boolean          default("unresigned"), not null # 退会状態
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  include_context 'Changesテーブルを有する場合', User
+end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Word, type: :model do
+  include_context 'Changesテーブルを有する場合', Word
+end

--- a/spec/models/word_spec.rb
+++ b/spec/models/word_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: words # 言葉
+#
+#  id          :bigint(8)        not null, primary key
+#  user_id     :bigint(8)        not null              # ユーザーID(FK)
+#  name        :string(255)      not null              # 名前
+#  phonetic    :string(255)      not null              # ふりがな
+#  description :string(255)      not null              # 説明
+#  created_at  :datetime         not null
+#
+
 require "rails_helper"
 
 RSpec.describe Word, type: :model do

--- a/spec/support/performable_with_changes_manager.rb
+++ b/spec/support/performable_with_changes_manager.rb
@@ -1,0 +1,133 @@
+# Changesテーブルを有するテーブル用のテスト。
+# PerformableWithChangesモジュールがincludeされていることを想定しており、モジュールのメソッドが正常に動作するかを確認する。
+# include_contextを利用して本テストをincludeして、引数に対象のクラス(Originalの方のクラス)を設定する必要がある。
+shared_context "Changesテーブルを有する場合" do |original_class|
+  describe "PerformableWithChangesモジュールをincludeしている場合" do
+    FACTORY_BOT_KEY = original_class.to_s.underscore.tr("/", "_").to_sym.freeze unless defined? FACTORY_BOT_KEY
+    ORIGINAL_CLASS = original_class unless defined? ORIGINAL_CLASS
+    CHANGES_CLASS = eval("#{original_class}Change", binding, __FILE__, __LINE__) unless defined? CHANGES_CLASS
+
+    let(:created_instance) { create(FACTORY_BOT_KEY) }
+    let(:builded_instance) { build(FACTORY_BOT_KEY) }
+
+    shared_context "OriginalのテーブルとChanges(履歴)テーブルのレコードそれぞれが正常に増減していること" do |original:, changes:|
+      it { expect{ subject }.to change(ORIGINAL_CLASS, :count).by(original).and change(CHANGES_CLASS, :count).by(changes) }
+    end
+
+    shared_context "Changesテーブルのeventが正常に登録されていること" do |event:|
+      it { expect{ subject }.to change{ CHANGES_CLASS.last&.event }.from(nil).to(event) }
+    end
+
+    shared_context "保存したレコードのインスタンスが返されること" do
+      it { is_expected.to eq ORIGINAL_CLASS.last }
+    end
+
+    shared_context "OriginalのテーブルとChanges(履歴)テーブルのレコードが増えていないこと" do
+      it do
+        expect{ subject }.to \
+          raise_error(ActiveRecord::RecordInvalid).and \
+          change(ORIGINAL_CLASS, :count).by(0).and \
+          change(CHANGES_CLASS, :count).by(0)
+      end
+    end
+
+    describe "save_with_changes!" do
+      subject { builded_instance.save_with_changes! }
+
+      context "保存処理が成功した場合" do
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードそれぞれが正常に増減していること", original: 1, changes: 1
+
+        include_context "Changesテーブルのeventが正常に登録されていること", event: "create"
+
+        include_context "保存したレコードのインスタンスが返されること"
+      end
+
+      context "保存処理に失敗した場合" do
+        before { allow(builded_instance).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
+
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードが増えていないこと"
+      end
+    end
+
+    describe "update_with_changes!" do
+      subject { created_instance.update_with_changes!(created_instance.attributes) }
+      before { created_instance }
+
+      context "更新処理が成功した場合" do
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードそれぞれが正常に増減していること", original: 0, changes: 1
+
+        include_context "Changesテーブルのeventが正常に登録されていること", event: "update"
+
+        include_context "保存したレコードのインスタンスが返されること"
+      end
+
+      context "保存処理に失敗した場合" do
+        before { allow(created_instance).to receive(:update!).and_raise(ActiveRecord::RecordInvalid) }
+
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードが増えていないこと"
+      end
+    end
+
+    describe "destroy_with_changes!" do
+      subject { created_instance.destroy_with_changes! }
+      before { created_instance }
+
+      context "保存処理が成功した場合" do
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードそれぞれが正常に増減していること", original: -1, changes: 1
+
+        include_context "Changesテーブルのeventが正常に登録されていること", event: "delete"
+
+        it "保存したレコードのインスタンスが返されること" do
+          is_expected.to eq created_instance
+        end
+      end
+
+      context "保存処理に失敗した場合" do
+        before { allow(created_instance).to receive(:destroy!).and_raise(ActiveRecord::RecordInvalid) }
+
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードが増えていないこと"
+      end
+    end
+
+    describe "create_with_changes!" do
+      subject { ORIGINAL_CLASS.create_with_changes!(builded_instance.attributes) }
+
+      context "保存処理が成功した場合" do
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードそれぞれが正常に増減していること", original: 1, changes: 1
+
+        include_context "Changesテーブルのeventが正常に登録されていること", event: "create"
+
+        include_context "保存したレコードのインスタンスが返されること"
+      end
+
+      context "保存処理に失敗した場合" do
+        before { allow(ORIGINAL_CLASS).to receive(:create!).and_raise(ActiveRecord::RecordInvalid) }
+
+        include_context "OriginalのテーブルとChanges(履歴)テーブルのレコードが増えていないこと"
+      end
+    end
+
+    describe "create_from_original!" do
+      subject { ORIGINAL_CLASS.send(:create_from_original!, original_record: created_instance, event: event) }
+
+      CHANGES_CLASS::CHANGES_EVENT_TYPES.each do |event|
+        context "enumに設定されているステータスをeventに入れた場合" do
+          let(:event) { event }
+          before { subject }
+
+          it "eventの内容が正常に保存されること" do
+            expect(CHANGES_CLASS.last.event).to eq event
+          end
+        end
+      end
+
+      context "eventに不正な内容が入っている場合" do
+        let(:event) { "HOGE" }
+
+        it "ActiveRecord::RecordInvalidが発生すること" do
+          expect{ subject }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changesテーブルが付いてくることで、
各Modelにいちいちsave_with_changes!とか書いていくのがかなり単調なので、
モジュール化してそれをincludeすればいいだけにした。

includeした時用のテストも共通化したので、
今後Changesテーブルを有するテーブルを作った時は、
1. Originalの方にPerformableWithChangesモジュール
2. Changesの方にCreatableFromOriginalモジュール
をincludeして、
Originalのテストに共通化テストをincludeすれば、
登録・更新・削除処理が利用可能になり、テストも勝手に追加されるようになっている。
