### PR TITLE
APIから取得したWordの末尾が消えるBugをFix

### DIFF
--- a/app/javascript/providers/Word/OrderLatestFetcher.ts
+++ b/app/javascript/providers/Word/OrderLatestFetcher.ts
@@ -31,7 +31,7 @@ class WordsOrderLatestFetcher extends BaseFetcher
 
     // 言葉を１つ以上取得できた場合は、最古のIDを更新
     if (words.length > 0) {
-      this.oldestFetchedId = words.pop().id;
+      this.oldestFetchedId = words[words.length - 1].id;
     }
 
     // リクエスト終了

--- a/app/javascript/providers/Word/ScopedFavoriteWordsFetcher.ts
+++ b/app/javascript/providers/Word/ScopedFavoriteWordsFetcher.ts
@@ -31,7 +31,7 @@ class ScopedFavoriteWordsFetcher extends BaseFetcher
 
     // 言葉を１つ以上取得できた場合は、最古のIDを更新
     if (words.length > 0) {
-      this.oldestFetchedId = words.pop().id;
+      this.oldestFetchedId = words[words.length - 1].id;
     }
 
     // リクエスト終了

--- a/app/javascript/providers/Word/ScopedFollowUsersFetcher.ts
+++ b/app/javascript/providers/Word/ScopedFollowUsersFetcher.ts
@@ -31,7 +31,7 @@ class ScopedFollowUsersFetcher extends BaseFetcher
 
     // 言葉を１つ以上取得できた場合は、最古のIDを更新
     if (words.length > 0) {
-      this.oldestFetchedId = words.pop().id;
+      this.oldestFetchedId = words[words.length - 1].id;
     }
 
     // リクエスト終了

--- a/app/javascript/providers/Word/ScopedUserFetcher.ts
+++ b/app/javascript/providers/Word/ScopedUserFetcher.ts
@@ -30,7 +30,7 @@ class ScopedUserFetcher extends BaseFetcher implements WordFetcherInterface {
 
     // 言葉を１つ以上取得できた場合は、最古のIDを更新
     if (words.length > 0) {
-      this.oldestFetchedId = words.pop().id;
+      this.oldestFetchedId = words[words.length - 1].id;
     }
 
     // リクエスト終了

--- a/app/javascript/providers/Word/SearchFetcher.ts
+++ b/app/javascript/providers/Word/SearchFetcher.ts
@@ -58,7 +58,7 @@ class WordsSearchFetcher extends BaseFetcher
 
     // 言葉を１つ以上取得できた場合は、最古のIDを更新
     if (words.length > 0) {
-      this.oldestFetchedId = words.pop().id;
+      this.oldestFetchedId = words[words.length - 1].id;
     }
 
     // リクエスト終了


### PR DESCRIPTION
pop()メソッドだと、
返り値返すだけじゃなくて、メソッドを使った配列自体から値を消しちゃうので、
普通のやり方に修正。