### PR TITLE
永続認証機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,21 +1,11 @@
 class ApplicationController < ActionController::Base
   include ExceptionHandlers unless Rails.env.development?
+  include SessionHelper
 
   protect_from_forgery with: :exception
   before_action :basic_authentication if ENV['BASIC_AUTH_USERNAME'].present? && ENV['BASIC_AUTH_PASSWORD'].present?
   before_action :authenticate
-  helper_method :logged_in?, :current_user
-
-  # ログイン処理を行うメソッド
-  def log_in(user)
-    session[:user_id] = user.id
-    UserAuthLog.create_success_log(user)
-  end
-
-  # ユーザーがログインをしているか確かめるメソッド
-  def logged_in?
-    current_user.present?
-  end
+  before_action :update_permanent_auth_token
 
   # ユーザー認証を行うメソッド
   def authenticate
@@ -26,9 +16,9 @@ class ApplicationController < ActionController::Base
     redirect_to new_user_profile_path if require_redirecting_to_new_profile?
   end
 
-  # sessionのuser_idを削除するメソッド
-  def log_out
-    session[:user_id] = nil
+  # 永続認証用のトークンを更新
+  def update_permanent_auth_token
+    update_remember_token if require_token_update?
   end
 
   # 認証ユーザーのベースページへのリダイレクト
@@ -38,22 +28,16 @@ class ApplicationController < ActionController::Base
 
   private
 
-    # ログイン中のユーザーのインスタンスを生成するメソッド(稼働中のもの)
-    def current_user
-      @current_user ||= User.active.find_by(id: session[:user_id])
+  # Basic認証
+  def basic_authentication
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['BASIC_AUTH_USERNAME'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
+  end
 
-    # プロフィール登録画面へのリダイレクトが必要かどうかの判定
-    # プロフィール未登録 && プロフィール登録ページにいない場合
-    def require_redirecting_to_new_profile?
-      current_user.profile.blank? && \
-        !(controller_name == "user_profiles" && (action_name == "new" || action_name == "create"))
-    end
-
-    # Basic認証
-    def basic_authentication
-      authenticate_or_request_with_http_basic do |username, password|
-        username == ENV['BASIC_AUTH_USERNAME'] && password == ENV['BASIC_AUTH_PASSWORD']
-      end
-    end
+  # プロフィール登録画面へのリダイレクトが必要かどうかの判定
+  # プロフィール未登録 && プロフィール登録ページにいない場合
+  def require_redirecting_to_new_profile?
+    current_user.profile.blank? && !(controller_name == "user_profiles" && ["new", "create"].include?(action_name))
+  end
 end

--- a/app/forms/user/login_form.rb
+++ b/app/forms/user/login_form.rb
@@ -1,0 +1,16 @@
+class User::LoginForm
+  include ActiveModel::Model
+
+  attr_accessor :email, :password, :user
+
+  # ユーザーのパスワード再設定処理
+  def authenticate
+    # paramsで取得したメールアドレスからユーザーを特定する
+    self.user = User.find_by(email: email)
+
+    # パスワードに誤りがあった場合はfalseを返却
+    return false unless user&.authenticate(password)
+
+    user
+  end
+end

--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,0 +1,79 @@
+# # 永続認証(Remember Me機能)について
+# 現状はログインした際、すべての認証を永続認証としている。
+# そのため、すべての認証で通常のRemember Me機能同様Cookieを利用して、永続認証される仕様となっている。
+# 永続認証の名前の通り、認証機関は無限(Cookieの最大保存機関の20年)としているため、セキュリティ的に問題があると考え、
+# 一定期間ごとにCookieに保存する認証トークンを更新する仕様にしている。
+# 将来的には、同時接続デバイス数を制限するなど、何かしらセキュリティを考慮した対策を設ける必要がある。
+
+module SessionHelper
+  # 永続認証用のトークンの持続時間(分単位)
+  PERMANENT_TOKEN_EXPIRED_MINITUES = 3
+
+  # ログイン処理を行うメソッド
+  def log_in(user)
+    remember_user(user) unless user.remember_me_token
+
+    session[:user_id] = user.id
+    UserAuthLog.create_success_log(user)
+  end
+
+  # ユーザーがログインをしているか確かめるメソッド
+  def logged_in?
+    current_user.present?
+  end
+
+  # sessionのuser_idを削除するメソッド
+  def log_out
+    current_user&.remember_me_token&.forget
+    session[:user_id] = nil
+    @current_user = nil
+  end
+
+  # ログイン中のユーザーのインスタンスを生成するメソッド(稼働中のもの)
+  def current_user
+    if session[:user_id]
+      @current_user ||= User.active.find_by(id: session[:user_id])
+    elsif cookies.signed[:user_id]
+      user = User.active.find_by(id: cookies.signed[:user_id])
+
+      if user&.remember_me_token&.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
+  end
+
+  # ユーザーの認証情報を永続的に記憶
+  def remember_user(user)
+    remember_token = User::RememberMeToken.remember(user)
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = remember_token
+    register_token_keeper
+  end
+
+  # ユーザーの永続認証用のトークンを更新
+  def update_remember_token
+    remember_token = current_user.remember_me_token.update_token
+    cookies.permanent[:remember_token] = remember_token
+    register_token_keeper
+  end
+
+  # 永続認証用トークンを維持するかを判定するかのCookieを生成
+  # このCookieが消えたタイミングで、永続認証用トークンを更新する。
+  def register_token_keeper
+    cookies[:token_keeper] = { value: 1, expires: PERMANENT_TOKEN_EXPIRED_MINITUES.minutes.from_now }
+  end
+
+  # 永続認証用トークンを更新する必要があるかの判定
+  def require_token_update?
+    cookies[:token_keeper].nil? && cookies.signed[:user_id].present? && cookies[:remember_token].present? && logged_in?
+  end
+
+  # 永続的セッションを破棄する
+  def forget_user(user)
+    user.remember_me_token&.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+    cookies.delete(:token_keeper)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
 
   has_one :profile, dependent: :destroy, class_name: "UserProfile"
   has_one :provisional_user_completed_log, dependent: :destroy
+  has_one :remember_me_token, dependent: :destroy
+
   has_many :freezed_reasons, dependent: :destroy
   has_many :unfreezed_reasons, dependent: :destroy
   has_many :resignation_requests, class_name: "User::Resignation::Request"

--- a/app/models/user/password_reissue_token.rb
+++ b/app/models/user/password_reissue_token.rb
@@ -3,10 +3,10 @@
 # Table name: user_password_reissue_tokens # ユーザー用のパスワード再発行用トークン
 #
 #  id         :bigint(8)        not null, primary key
-#  user_id    :bigint(8)        not null              # ユーザーID(FK)
-#  email      :string(255)      not null              # メールアドレス
-#  token      :string(255)      not null              # トークン
-#  consumed   :boolean          not null              # 利用済み
+#  user_id    :bigint(8)        not null                        # ユーザーID(FK)
+#  email      :string(255)      not null                        # メールアドレス
+#  token      :string(255)      not null                        # トークン
+#  consumed   :boolean          default("unconsumed"), not null # 利用済み
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/user/password_reissue_token_change.rb
+++ b/app/models/user/password_reissue_token_change.rb
@@ -3,12 +3,12 @@
 # Table name: user_password_reissue_token_changes # ユーザー用のパスワード再発行用トークンの履歴
 #
 #  id                             :bigint(8)        not null, primary key
-#  user_password_reissue_token_id :bigint(8)        not null              # 再発行用トークンID
-#  user_id                        :bigint(8)        not null              # ユーザーID(FK)
-#  email                          :string(255)      not null              # メールアドレス
-#  token                          :string(255)      not null              # トークン
-#  consumed                       :boolean          not null              # 利用済み
-#  event                          :string(255)      not null              # イベント
+#  user_password_reissue_token_id :bigint(8)        not null                        # 再発行用トークンID
+#  user_id                        :bigint(8)        not null                        # ユーザーID(FK)
+#  email                          :string(255)      not null                        # メールアドレス
+#  token                          :string(255)      not null                        # トークン
+#  consumed                       :boolean          default("unconsumed"), not null # 利用済み
+#  event                          :string(255)      not null                        # イベント
 #  created_at                     :datetime         not null
 #
 

--- a/app/models/user/remember_me_token.rb
+++ b/app/models/user/remember_me_token.rb
@@ -1,0 +1,59 @@
+# == Schema Information
+#
+# Table name: user_remember_me_tokens # ユーザーのRemember Me機能に利用するトークン
+#
+#  id           :bigint(8)        not null, primary key
+#  user_id      :bigint(8)        not null              # ユーザーID(FK)
+#  token_digest :string(255)      not null              # 認証用トークン
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+class User::RememberMeToken < ApplicationRecord
+  include PerformableWithChanges
+
+  attr_accessor :remember_token
+
+  belongs_to :user
+  validates :user_id, uniqueness: true
+  validates :token_digest, presence: true
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返却
+  def authenticated?(remember_token)
+    BCrypt::Password.new(token_digest).is_password?(remember_token)
+  end
+
+  # ユーザーのログイン情報を破棄
+  def forget
+    destroy_with_changes!
+  end
+
+  # 永続認証用のトークンを更新
+  def update_token
+    self.remember_token = User::RememberMeToken.generate_token
+    update_with_changes!(token_digest: User::RememberMeToken.generate_digest(remember_token))
+    remember_token
+  end
+
+  class << self
+    # 永続認証用のトークンを保存
+    def remember(user)
+      raise if user.remember_me_token
+
+      token = generate_token
+      create_with_changes!(user_id: user.id, token_digest: generate_digest(token))
+      token
+    end
+
+    # トークンをハッシュ化
+    def generate_digest(token)
+      cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+      BCrypt::Password.create(token, cost: cost)
+    end
+
+    # トークンを生成
+    def generate_token
+      SecureRandom.uuid
+    end
+  end
+end

--- a/app/models/user/remember_me_token_change.rb
+++ b/app/models/user/remember_me_token_change.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: user_remember_me_token_changes # ユーザーのRemember Me機能に利用するトークンの履歴
+#
+#  id                        :bigint(8)        not null, primary key
+#  user_remember_me_token_id :bigint(8)        not null              # Remember MeトークンID
+#  user_id                   :bigint(8)        not null              # ユーザーID
+#  token_digest              :string(255)      not null              # 認証用トークン
+#  event                     :string(255)      not null              # イベント
+#  created_at                :datetime         not null
+#
+
+class User::RememberMeTokenChange < ApplicationRecord
+  include CreatableFromOriginal
+  ORIGINAL_FOREIGN_KEY = :user_remember_me_token_id
+
+  validates :user_id, presence: true
+  validates :token_digest, presence: true
+end

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -6,7 +6,7 @@ ruby:
   provide :template_stylesheet_path, "sessions/new"
   provide :container_type, "form"
 
-= form_for @user, url: login_path, html: { class: "base-form" } do |f|
+= form_for @login_form, url: login_path, html: { class: "base-form" } do |f|
   .form-group
     .label-field
       = f.label :email

--- a/config/locales/forms/user/login_form.ja.yml
+++ b/config/locales/forms/user/login_form.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activemodel:
+    attributes:
+      user/login_form:
+        email: メールアドレス
+        password: パスワード

--- a/db/migrate/20180908005523_create_user_remember_me_tokens.rb
+++ b/db/migrate/20180908005523_create_user_remember_me_tokens.rb
@@ -1,0 +1,9 @@
+class CreateUserRememberMeTokens < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_remember_me_tokens, comment: "ユーザーのRemember Me機能に利用するトークン" do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }, comment: "ユーザーID(FK)"
+      t.string :token_digest, null: false, comment: "認証用トークン"
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180908010017_create_user_remember_me_token_changes.rb
+++ b/db/migrate/20180908010017_create_user_remember_me_token_changes.rb
@@ -1,0 +1,11 @@
+class CreateUserRememberMeTokenChanges < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_remember_me_token_changes, comment: "ユーザーのRemember Me機能に利用するトークンの履歴" do |t|
+      t.bigint :user_remember_me_token_id, null: false, comment: "Remember MeトークンID"
+      t.bigint :user_id, null: false, comment: "ユーザーID"
+      t.string :token_digest, null: false, comment: "認証用トークン"
+      t.string :event, null: false, comment: "イベント"
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_20_201652) do
+ActiveRecord::Schema.define(version: 2018_09_08_010017) do
+
   create_table "admin_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "管理者ユーザー", force: :cascade do |t|
     t.string "email", null: false, comment: "メールアドレス"
     t.string "uid", comment: "OAuth用のユニークID"
@@ -139,6 +140,22 @@ ActiveRecord::Schema.define(version: 2018_08_20_201652) do
     t.index ["user_id"], name: "index_user_profiles_on_user_id", unique: true
   end
 
+  create_table "user_remember_me_token_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "ユーザーのRemember Me機能に利用するトークンの履歴", force: :cascade do |t|
+    t.bigint "user_remember_me_token_id", null: false, comment: "Remember MeトークンID"
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.string "token_digest", null: false, comment: "認証用トークン"
+    t.string "event", null: false, comment: "イベント"
+    t.datetime "created_at", null: false
+  end
+
+  create_table "user_remember_me_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "ユーザーのRemember Me機能に利用するトークン", force: :cascade do |t|
+    t.bigint "user_id", null: false, comment: "ユーザーID(FK)"
+    t.string "token_digest", null: false, comment: "認証用トークン"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_remember_me_tokens_on_user_id", unique: true
+  end
+
   create_table "user_resignation_request_cancels", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", comment: "ユーザーの退会申請のキャンセルが格納されるテーブル", force: :cascade do |t|
     t.bigint "user_id", null: false, comment: "ユーザーID"
     t.string "description", null: false, comment: "退会キャンセル理由"
@@ -215,6 +232,7 @@ ActiveRecord::Schema.define(version: 2018_08_20_201652) do
   add_foreign_key "user_freezed_reasons", "users"
   add_foreign_key "user_password_reissue_tokens", "users"
   add_foreign_key "user_profiles", "users"
+  add_foreign_key "user_remember_me_tokens", "users"
   add_foreign_key "user_unfreezed_reasons", "users"
   add_foreign_key "word_random_fetched_records", "word_random_fetched_tokens", column: "token_id"
   add_foreign_key "word_random_fetched_records", "words"

--- a/spec/factories/user_remember_me_tokens.rb
+++ b/spec/factories/user_remember_me_tokens.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: user_remember_me_tokens # ユーザーのRemember Me機能に利用するトークン
+#
+#  id           :bigint(8)        not null, primary key
+#  user_id      :bigint(8)        not null              # ユーザーID(FK)
+#  token_digest :string(255)      not null              # 認証用トークン
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+FactoryBot.define do
+  factory :user_remember_me_token, class: User::RememberMeToken do
+    token_digest "xxxxxxxxxxxxxxxxxxxxxxx"
+    association :user
+  end
+end

--- a/spec/helpers/session_helper_spec.rb
+++ b/spec/helpers/session_helper_spec.rb
@@ -1,0 +1,207 @@
+require 'rails_helper'
+
+# SessionHelperはApplicationControllerにincludeされることを前提として作られているため、
+# テストもinclude先のApplicationControllerを中心として行う。
+RSpec.describe ApplicationController, type: :controller do
+  controller(ApplicationController) do
+    include SessionHelper
+  end
+
+  let(:user) { create(:user) }
+  let(:cookies) { controller.send(:cookies) }
+  let(:session) { controller.session }
+
+  describe "#log_in" do
+    subject { controller.log_in(user) }
+
+    context "正常にログインした場合" do
+      it "永続ログイン状態になり、ログイン成功記録が登録されること", :aggregate_failures do
+        expect{ subject }.to change(User::RememberMeToken, :count).by(1).and \
+          change(User::RememberMeTokenChange, :count).by(1).and \
+          change(UserAuthLog, :count).by(1)
+        expect(User::RememberMeTokenChange.last&.event).to eq("create")
+        expect(UserAuthLog.last&.success).to eq true
+        expect(session[:user_id]).to eq(user.id)
+      end
+    end
+  end
+
+  describe "logged_in?" do
+    subject { controller.logged_in? }
+
+    context "ログイン状態の場合" do
+      context "セッションにログイン情報が保存されている場合" do
+        before { session.merge!({ user_id: user.id }) }
+        it { is_expected.to eq true }
+      end
+
+      context "Cookieに永続ログイン情報が保存されている場合" do
+        before do
+          remember_token = User::RememberMeToken.remember(user)
+          cookies.permanent.signed[:user_id] = user.id
+          cookies.permanent[:remember_token] = remember_token
+        end
+
+        it { is_expected.to eq true }
+      end
+    end
+
+    context "未ログイン状態の場合" do
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe "log_out" do
+    subject { controller.log_out }
+
+    context "正常にログアウトした場合" do
+      before { controller.log_in(user) }
+      it "session, @current_userが初期化され、永続認証用トークンが削除されること", :aggregate_failures do
+        expect{ subject }.to change{ session[:user_id] }.from(user.id).to(nil).and \
+          change{ controller.current_user }.from(user).to(nil).and \
+          change(User::RememberMeToken, :count).by(-1).and \
+          change(User::RememberMeTokenChange, :count).by(1)
+        expect(User::RememberMeTokenChange.last&.event).to eq("delete")
+      end
+    end
+  end
+
+  describe "current_user" do
+    subject { controller.current_user }
+
+    context "Sessionにuser_idが格納されている場合" do
+      before { session.merge!({ user_id: user.id }) }
+
+      it "user_idに該当するユーザーのインスタンスが返されること" do
+        is_expected.to eq user
+      end
+    end
+
+    context "Cookieに永続認証情報が格納されている場合" do
+      before do
+        remember_token = User::RememberMeToken.remember(user)
+        cookies.permanent.signed[:user_id] = user.id
+        cookies.permanent[:remember_token] = remember_token
+      end
+
+      it "user_idに該当するユーザーのインスタンスが返されること" do
+        is_expected.to eq user
+      end
+    end
+
+    context "Session, Cookieともに存在しない場合" do
+      it { is_expected.to eq nil }
+    end
+  end
+
+  describe "remember_user" do
+    subject { controller.remember_user(user) }
+
+    context "正常に保存できた場合" do
+      it "トークンがDBに登録されていること", :aggregate_failures do
+        expect{ subject }.to change(User::RememberMeToken, :count).by(1).and \
+          change(User::RememberMeTokenChange, :count).by(1)
+        expect(User::RememberMeTokenChange.last&.event).to eq("create")
+      end
+
+      it "永続認証用のCookieが保存されていること", :aggregate_failures do
+        subject
+        expect(cookies.signed[:user_id]).to eq(user.id)
+        expect(cookies[:remember_token].present?).to eq true
+        expect(cookies[:token_keeper].present?).to eq true
+      end
+    end
+  end
+
+  describe "update_remember_token" do
+    subject { controller.update_remember_token }
+    before do
+      remember_me_token
+      controller.log_in(user)
+    end
+    let(:remember_me_token) { create(:user_remember_me_token, user_id: user.id) }
+
+    context "正常に保存できた場合" do
+      it "トークンが更新され、履歴が登録されていること", :aggregate_failures do
+        expect{ subject }.to change(User::RememberMeToken, :count).by(0).and \
+          change(User::RememberMeTokenChange, :count).by(1)
+        expect(User::RememberMeTokenChange.last&.event).to eq("update")
+      end
+
+      it "永続認証用のCookieが保存されていること", :aggregate_failures do
+        subject
+        expect(user.reload.remember_me_token.token_digest).not_to eq remember_me_token.token_digest
+        expect(cookies[:remember_token].present?).to eq true
+        expect(cookies[:token_keeper].present?).to eq true
+      end
+    end
+  end
+
+  describe "register_token_keeper" do
+    subject { controller.register_token_keeper }
+    before { subject }
+    it "1が返されること" do
+      expect(cookies[:token_keeper]).to eq 1
+    end
+  end
+
+  describe "require_token_update?" do
+    subject { controller.require_token_update? }
+    before do
+      remember_token = User::RememberMeToken.remember(user)
+      cookies.permanent.signed[:user_id] = user.id
+      cookies.permanent[:remember_token] = remember_token
+      cookies[:token_keeper] = nil
+    end
+
+    context "トークンを更新する必要がある場合" do
+      it { is_expected.to eq true }
+    end
+
+    context "トークンを更新する必要がない場合" do
+      context "Cookieのtoken_keeperが存在する場合" do
+        before { cookies.permanent[:token_keeper] = 1 }
+        it { is_expected.to eq false }
+      end
+
+      context "Cookieのuser_idが存在しない場合" do
+        before { cookies.permanent[:user_id] = nil }
+        it { is_expected.to eq false }
+      end
+
+      context "Cookieのremember_tokenが存在しない場合" do
+        before { cookies[:remember_token] = nil }
+        it { is_expected.to eq false }
+      end
+
+      context "ログイン中でない場合" do
+        it do
+          allow(controller).to receive(:logged_in?).and_return(false)
+          is_expected.to eq false
+        end
+      end
+    end
+  end
+
+  describe "forget_user" do
+    subject { controller.forget_user(user) }
+    before do
+      controller.remember_user(user)
+      user.reload
+    end
+
+    context "正常に削除できた場合" do
+      it "認証用トークンのレコードが削除され、履歴が残っていること", :aggregate_failures do
+        expect{ subject }.to change(User::RememberMeToken, :count).by(-1).and \
+          change(User::RememberMeTokenChange, :count).by(1)
+        expect(User::RememberMeTokenChange.last&.event).to eq("delete")
+      end
+
+      it "認証用のCookieが削除されていること" do
+        expect{ subject }.to change{ cookies[:user_id].present? }.from(true).to(false).and \
+          change{ cookies[:remember_token].present? }.from(true).to(false).and \
+          change{ cookies[:token_keeper].present? }.from(true).to(false)
+      end
+    end
+  end
+end

--- a/spec/models/user/remember_me_token_spec.rb
+++ b/spec/models/user/remember_me_token_spec.rb
@@ -1,0 +1,86 @@
+# == Schema Information
+#
+# Table name: user_remember_me_tokens # ユーザーのRemember Me機能に利用するトークン
+#
+#  id           :bigint(8)        not null, primary key
+#  user_id      :bigint(8)        not null              # ユーザーID(FK)
+#  token_digest :string(255)      not null              # 認証用トークン
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+require "rails_helper"
+
+RSpec.describe User::RememberMeToken, type: :model do
+  include_context 'Changesテーブルを有する場合', User::RememberMeToken
+  let(:remember_me_token) { create(:user_remember_me_token, token_digest: token_digest) }
+  let(:token_digest) { User::RememberMeToken.generate_digest(remember_token) }
+  let(:remember_token) { User::RememberMeToken.generate_token }
+
+  describe "Instanceメソッド" do
+    describe "#authenticated?" do
+      subject { remember_me_token.authenticated?(remember_token_arg) }
+
+      context "トークンが正しい場合" do
+        let(:remember_token_arg) { remember_token }
+        it { is_expected.to eq true }
+      end
+
+      context "トークンが不正な場合" do
+        let(:remember_token_arg) { "hoge" }
+        it { is_expected.to eq false }
+      end
+    end
+
+    describe "#forget" do
+      subject { remember_me_token.forget }
+      before { remember_me_token }
+
+      context "正常にトークンが削除された場合" do
+        it "レコードが削除され、その履歴が残ること", :aggregate_failures do
+          expect{ subject }.to change(User::RememberMeToken, :count).by(-1).and \
+            change(User::RememberMeTokenChange, :count).by(1)
+          expect(User::RememberMeTokenChange.last&.event).to eq("delete")
+        end
+      end
+    end
+
+    describe "#update_token" do
+      context "正常にトークンを更新した場合" do
+        subject { remember_me_token.update_token }
+        before { remember_me_token }
+
+        it "レコードが更新され、その履歴が残ること", :aggregate_failures do
+          expect{ subject }.to change(User::RememberMeToken, :count).by(0).and \
+            change(User::RememberMeTokenChange, :count).by(1)
+          expect(User::RememberMeTokenChange.last&.event).to eq("update")
+        end
+
+        it "認証トークンが更新されること" do
+          expect{ subject }.to change{ remember_me_token.authenticated?(remember_token) }.from(true).to(false)
+        end
+      end
+    end
+  end
+
+  describe "Classメソッド" do
+    describe ".remember" do
+      subject { User::RememberMeToken.remember(user) }
+      let(:user) { create(:user) }
+
+      context "トークンがまだ未登録の場合" do
+        it "トークンが登録され、履歴が残ること", :aggregate_failures do
+          expect{ subject }.to change(User::RememberMeToken, :count).by(1).and \
+            change(User::RememberMeTokenChange, :count).by(1)
+          expect(User::RememberMeTokenChange.last&.event).to eq("create")
+        end
+      end
+
+      context "トークンが登録済みの場合" do
+        # トークンが登録されている場合にこのメソッドを利用できないように例外が発生
+        before { create(:user_remember_me_token, user_id: user.id) }
+        it { expect{ subject }.to raise_error(RuntimeError) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 永続認証用トークンの保存方法
通常、認証用のトークンを格納する場所はusers.passwordと同じusersテーブルにする方が一般的だけど、
Railsの場合テーブルとModelクラスが1対1に紐づいていて、もしもusersテーブルに認証用のトークンを格納したら、認証用トークン用の処理がusersクラスに追記されて一気にクラスが膨らむことになるので、
そうならないように別のuser_remember_me_tokensテーブルを作成して、クラスを分けるように実装している。

### 備考
Session関係の処理がApplicationControllerに大量に増えて、一気にクラスのコードが膨らんできたので、
SessionHelperモジュールとして外に切り出した。
これについてはHelperだったが、重要機能だったのでテストを書いている。
また、LoginフォームのところがControllerにロジックがそのまま書かれた状態だったので、
新しくUser::LoginFormクラスを作成して、そっちにロジックを移すように改修した。

### セキュリティについて
以下の参考資料を読んでもわかるが、永続認証は外部にトークンが漏れた瞬間に、
誰でもパスワードなしでアカウントを使えるようになってしまい、
セキュリティ的に懸念点がある。
本来は期限を設定するか同時アクセスできるデバイス数に制限を設けるかするべきだが、
期限を設けると実装した意味が半減してしまいUX的に微妙になるのと、
デバイス数の制限は少し工数がかかるので、
暫定的にトークンを一定期間ごとに更新するようにして、外部にトークンが漏れても
一定期間で無効になるように対応した。
(現時点では3分でトークンは無効になるようにしてある。
ただし、Cookieの性質上、3分以上経過した後にユーザーが再度アクセスしないと無効にならない仕様。)

### 参考資料
永続認証(Remember Me機能)について
http://rennnosukesann.hatenablog.com/entry/2018/02/17/225921