### PR TITLE
ダッシュボードに色々なデータを表示

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -16,6 +16,13 @@ class Admin::ApplicationController < ActionController::Base
     session[:admin_user_id] = nil
   end
 
+  # ActiveRecordをSQLに直して実行する処理
+  def excute_sql(active_record)
+    con = ActiveRecord::Base.connection
+    result = con.select_all(active_record.to_sql)
+    result.to_hash
+  end
+
   private
 
   # 管理者用の認証処理

--- a/app/controllers/admin/dashboard/ranking/users_controller.rb
+++ b/app/controllers/admin/dashboard/ranking/users_controller.rb
@@ -1,0 +1,110 @@
+# Adminでしか利用しない特殊なロジックが多いので、基本的にはModelには切り出さない方針でやっている。
+# 今後ControllerがFatになるようなら、それぞれ別Controllerのクラスとして切り分けるなり対応する。
+class Admin::Dashboard::Ranking::UsersController < Admin::ApplicationController
+  # お気に入りされている言葉の多いユーザーランキング
+  def favorited_words
+    seed = ::User.select("users.id as user_id")
+                 .select("count(favorites.id) as favorite_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(:profile)
+                 .joins(words: :favorites)
+                 .group("users.id")
+                 .order("favorite_count desc")
+                 .limit(50)
+
+    seed = seed.where("words.created_at >= ?", params[:word_start_date]) if params[:word_start_date].present?
+    seed = seed.where("words.created_at <= ?", params[:word_end_date]) if params[:word_end_date].present?
+    if params[:favorite_start_date].present?
+      seed = seed.where("favorites.created_at >= ?", params[:favorite_start_date])
+    end
+    seed = seed.where("favorites.created_at <= ?", params[:favorite_end_date]) if params[:favorite_end_date].present?
+
+    @rows = excute_sql(seed)
+  end
+
+  # お気に入りしている言葉の多いユーザーランキング
+  def favoriting_words
+    seed = ::User.select("users.id as user_id")
+                 .select("count(favorites.id) as favorite_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(:profile)
+                 .joins(:favorites)
+                 .group("users.id")
+                 .order("favorite_count desc")
+                 .limit(50)
+
+    seed = seed.where("words.created_at >= ?", params[:word_start_date]) if params[:word_start_date].present?
+    seed = seed.where("words.created_at <= ?", params[:word_end_date]) if params[:word_end_date].present?
+    if params[:favorite_start_date].present?
+      seed = seed.where("favorites.created_at >= ?", params[:favorite_start_date])
+    end
+    seed = seed.where("favorites.created_at <= ?", params[:favorite_end_date]) if params[:favorite_end_date].present?
+
+    @rows = excute_sql(seed)
+  end
+
+  # 投稿数の多いユーザーランキング
+  def posted_words
+    seed = ::User.select("users.id as user_id")
+                 .select("count(words.id) as word_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(:profile)
+                 .joins(:words)
+                 .group("users.id")
+                 .order("word_count desc")
+                 .limit(50)
+
+    seed = seed.where("users.created_at >= ?", params[:user_start_date]) if params[:user_start_date].present?
+    seed = seed.where("users.created_at <= ?", params[:user_end_date]) if params[:user_end_date].present?
+    seed = seed.where("words.created_at >= ?", params[:word_start_date]) if params[:word_start_date].present?
+    seed = seed.where("words.created_at <= ?", params[:word_end_date]) if params[:word_end_date].present?
+
+    @rows = excute_sql(seed)
+  end
+
+  # フォロワー数の多いユーザーランキング
+  def followed
+    seed = ::User.select("users.id as user_id")
+                 .select("count(user_follow_relations.id) as followed_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(:profile)
+                 .joins(:followed_relations)
+                 .group("users.id")
+                 .order("followed_count desc")
+                 .limit(50)
+
+    seed = seed.where("users.created_at >= ?", params[:user_start_date]) if params[:user_start_date].present?
+    seed = seed.where("users.created_at <= ?", params[:user_end_date]) if params[:user_end_date].present?
+    if params[:followed_start_date].present?
+      seed = seed.where("user_follow_relations.created_at >= ?", params[:followed_start_date])
+    end
+    if params[:followed_end_date].present?
+      seed = seed.where("user_follow_relations.created_at <= ?", params[:followed_end_date])
+    end
+
+    @rows = excute_sql(seed)
+  end
+
+  # フォロー数の多いユーザーランキング
+  def following
+    seed = ::User.select("users.id as user_id")
+                 .select("count(user_follow_relations.id) as follow_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(:profile)
+                 .joins(:follow_relations)
+                 .group("users.id")
+                 .order("follow_count desc")
+                 .limit(50)
+
+    seed = seed.where("users.created_at >= ?", params[:user_start_date]) if params[:user_start_date].present?
+    seed = seed.where("users.created_at <= ?", params[:user_end_date]) if params[:user_end_date].present?
+    if params[:follow_start_date].present?
+      seed = seed.where("user_follow_relations.created_at >= ?", params[:follow_start_date])
+    end
+    if params[:follow_end_date].present?
+      seed = seed.where("user_follow_relations.created_at <= ?", params[:follow_end_date])
+    end
+
+    @rows = excute_sql(seed)
+  end
+end

--- a/app/controllers/admin/dashboard/ranking/words_controller.rb
+++ b/app/controllers/admin/dashboard/ranking/words_controller.rb
@@ -1,0 +1,22 @@
+class Admin::Dashboard::Ranking::WordsController < Admin::ApplicationController
+  # お気に入りされている数の多い言葉ランキング
+  def favorited
+    seed = ::Word.select("words.id as word_id")
+                 .select("words.name as word_name")
+                 .select("words.description as word_description")
+                 .select("count(favorites.id) as favorite_count")
+                 .select("concat(user_profiles.last_name, user_profiles.first_name) as full_name")
+                 .eager_load(user: :profile)
+                 .joins(:favorites)
+                 .group("words.id")
+                 .order("favorite_count desc")
+                 .limit(50)
+
+    seed = seed.where("users.created_at >= ?", params[:user_start_date]) if params[:user_start_date].present?
+    seed = seed.where("users.created_at <= ?", params[:user_end_date]) if params[:user_end_date].present?
+    seed = seed.where("words.created_at >= ?", params[:word_start_date]) if params[:word_start_date].present?
+    seed = seed.where("words.created_at <= ?", params[:word_end_date]) if params[:word_end_date].present?
+
+    @rows = excute_sql(seed)
+  end
+end

--- a/app/controllers/admin/dashboard/transition/favorites_controller.rb
+++ b/app/controllers/admin/dashboard/transition/favorites_controller.rb
@@ -1,0 +1,23 @@
+class Admin::Dashboard::Transition::FavoritesController < Admin::ApplicationController
+  include Admin::DateHandler
+
+  # お気に入り数の推移
+  def favorite
+    seed = ::Favorite.select("date(favorites.created_at) as date_at")
+                     .select("count(favorites.id) as favorite_count")
+                     .group("date_at")
+                     .order("date_at")
+                     .limit(100)
+
+    start_date, end_date = fetch_target_period_dates(params[:start_date], params[:end_date])
+
+    seed = seed.where("favorites.created_at >= ?", start_date)
+    seed = seed.where("favorites.created_at <= ?", end_date)
+
+    rows = excute_sql(seed)
+    daily_count_hash = array_to_daily_hash(rows, "favorite_count")
+
+    # 件数が0件の日にちは取得できずに歯抜けになるので、その分のkeyを埋める
+    @daily_counts = fill_missing_date_with_zero(daily_count_hash, start_date, end_date)
+  end
+end

--- a/app/controllers/admin/dashboard/transition/follows_controller.rb
+++ b/app/controllers/admin/dashboard/transition/follows_controller.rb
@@ -1,0 +1,23 @@
+class Admin::Dashboard::Transition::FollowsController < Admin::ApplicationController
+  include Admin::DateHandler
+
+  # フォロー数の推移
+  def follow
+    seed = ::User::FollowRelation.select("date(user_follow_relations.created_at) as date_at")
+                                 .select("count(user_follow_relations.id) as follow_count")
+                                 .group("date_at")
+                                 .order("date_at")
+                                 .limit(100)
+
+    start_date, end_date = fetch_target_period_dates(params[:start_date], params[:end_date])
+
+    seed = seed.where("user_follow_relations.created_at >= ?", start_date)
+    seed = seed.where("user_follow_relations.created_at <= ?", end_date)
+
+    rows = excute_sql(seed)
+    daily_count_hash = array_to_daily_hash(rows, "follow_count")
+
+    # 件数が0件の日にちは取得できずに歯抜けになるので、その分のkeyを埋める
+    @daily_counts = fill_missing_date_with_zero(daily_count_hash, start_date, end_date)
+  end
+end

--- a/app/controllers/admin/dashboard/transition/users_controller.rb
+++ b/app/controllers/admin/dashboard/transition/users_controller.rb
@@ -1,0 +1,23 @@
+class Admin::Dashboard::Transition::UsersController < Admin::ApplicationController
+  include Admin::DateHandler
+
+  # ユーザーの登録数の推移
+  def registered
+    seed = ::User.select("date(users.created_at) as date_at")
+                 .select("count(users.id) as user_count")
+                 .group("date_at")
+                 .order("date_at")
+                 .limit(100)
+
+    start_date, end_date = fetch_target_period_dates(params[:start_date], params[:end_date])
+
+    seed = seed.where("users.created_at >= ?", start_date)
+    seed = seed.where("users.created_at <= ?", end_date)
+
+    rows = excute_sql(seed)
+    daily_count_hash = array_to_daily_hash(rows, "user_count")
+
+    # 件数が0件の日にちは取得できずに歯抜けになるので、その分のkeyを埋める
+    @daily_counts = fill_missing_date_with_zero(daily_count_hash, start_date, end_date)
+  end
+end

--- a/app/controllers/admin/dashboard/transition/words_controller.rb
+++ b/app/controllers/admin/dashboard/transition/words_controller.rb
@@ -1,0 +1,23 @@
+class Admin::Dashboard::Transition::WordsController < Admin::ApplicationController
+  include Admin::DateHandler
+
+  # 言葉の投稿数の推移
+  def posted
+    seed = ::Word.select("date(words.created_at) as date_at")
+                 .select("count(words.id) as word_count")
+                 .group("date_at")
+                 .order("date_at")
+                 .limit(100)
+
+    start_date, end_date = fetch_target_period_dates(params[:start_date], params[:end_date])
+
+    seed = seed.where("words.created_at >= ?", start_date)
+    seed = seed.where("words.created_at <= ?", end_date)
+
+    rows = excute_sql(seed)
+    daily_count_hash = array_to_daily_hash(rows, "word_count")
+
+    # 件数が0件の日にちは取得できずに歯抜けになるので、その分のkeyを埋める
+    @daily_counts = fill_missing_date_with_zero(daily_count_hash, start_date, end_date)
+  end
+end

--- a/app/controllers/concerns/admin/date_handler.rb
+++ b/app/controllers/concerns/admin/date_handler.rb
@@ -1,0 +1,30 @@
+module Admin::DateHandler
+  FETCHABLE_MAX_DAYS = 100
+
+  # 日付をキーとしたハッシュの空いた日付を0で埋める
+  def fill_missing_date_with_zero(daily_hash, start_date, end_date)
+    (start_date..end_date).map do |date|
+      if daily_hash[date].present?
+        { date => daily_hash[date] }
+      else
+        { date => 0 }
+      end
+    end.reduce(:merge)
+  end
+
+  # 取得対象期間の日付を取得
+  def fetch_target_period_dates(start_date, end_date)
+    start_date = start_date.present? ? params[:start_date].to_date : 30.days.ago.to_date
+
+    end_date = end_date.present? ? end_date.to_date : Time.current.to_date
+
+    end_date = start_date + FETCHABLE_MAX_DAYS if start_date + FETCHABLE_MAX_DAYS < end_date
+
+    return start_date, end_date
+  end
+
+  # 配列を日付をkeyにしたハッシュに変換
+  def array_to_daily_hash(array, key_name)
+    array.length > 0 ? array.map{ |v| { v["date_at"] => v[key_name] } }.reduce(:merge) : {}
+  end
+end

--- a/app/javascript/packs/admin/dashboard/favorites/favorite.tsx
+++ b/app/javascript/packs/admin/dashboard/favorites/favorite.tsx
@@ -1,0 +1,3 @@
+import DefaultChart from "../../../../providers/Admin/DefaultChart";
+
+DefaultChart.drawChart("chart", "お気に入り数");

--- a/app/javascript/packs/admin/dashboard/follows/follow.tsx
+++ b/app/javascript/packs/admin/dashboard/follows/follow.tsx
@@ -1,0 +1,3 @@
+import DefaultChart from "../../../../providers/Admin/DefaultChart";
+
+DefaultChart.drawChart("chart", "フォロー数");

--- a/app/javascript/packs/admin/dashboard/users/registered.tsx
+++ b/app/javascript/packs/admin/dashboard/users/registered.tsx
@@ -1,0 +1,3 @@
+import DefaultChart from "../../../../providers/Admin/DefaultChart";
+
+DefaultChart.drawChart("chart", "登録数");

--- a/app/javascript/packs/admin/dashboard/words/posted.tsx
+++ b/app/javascript/packs/admin/dashboard/words/posted.tsx
@@ -1,0 +1,3 @@
+import DefaultChart from "../../../../providers/Admin/DefaultChart";
+
+DefaultChart.drawChart("chart", "投稿数");

--- a/app/javascript/providers/Admin/DefaultChart.ts
+++ b/app/javascript/providers/Admin/DefaultChart.ts
@@ -1,0 +1,48 @@
+import Chart from "chart.js";
+
+const drawChart = (chartElmId: string, labelName: string) => {
+  const chartElm: any = document.getElementById(chartElmId);
+  const data: any = JSON.parse(chartElm.dataset.amounts);
+
+  const labels: any = [];
+  const countData: any = [];
+
+  Object.keys(data).forEach((date: string) => {
+    labels.push(date);
+    countData.push(data[date]);
+  });
+
+  return new Chart(chartElm.getContext("2d"), {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        {
+          label: labelName,
+          data: countData,
+          pointRadius: 5,
+          lineTension: 0,
+          pointBackgroundColor: "#fff",
+          backgroundColor: "rgba(52,181,226,0.4)",
+          borderColor: "#34B5E2"
+        }
+      ]
+    },
+    options: {
+      scales: {
+        yAxes: [
+          {
+            ticks: {
+              beginAtZero: true,
+              min: 0
+            }
+          }
+        ]
+      }
+    }
+  });
+};
+
+export default {
+  drawChart
+};

--- a/app/views/admin/dashboard/ranking/users/_ranking_menu.html.slim
+++ b/app/views/admin/dashboard/ranking/users/_ranking_menu.html.slim
@@ -1,0 +1,14 @@
+h5
+  | ユーザーランキング
+= link_to "お気に入りされている言葉の多いユーザー", favorited_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+| &nbsp;
+= link_to "お気に入りしている言葉の多いユーザー", favoriting_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+| &nbsp;
+= link_to "投稿数の多いユーザー", posted_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+| &nbsp;
+= link_to "フォロワー数の多いユーザー", followed_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+| &nbsp;
+= link_to "フォロー数の多いユーザー", following_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+| &nbsp;
+
+hr

--- a/app/views/admin/dashboard/ranking/users/favorited_words.html.slim
+++ b/app/views/admin/dashboard/ranking/users/favorited_words.html.slim
@@ -1,0 +1,47 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入りされている言葉の多いユーザー
+
+  .panel-body
+    = render partial: "admin/dashboard/ranking/users/ranking_menu"
+
+    h5
+      | 「言葉の投稿日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :word_start_date, params[:word_start_date]
+      | 〜
+      = date_field_tag :word_end_date, params[:word_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    h5
+      | 「お気に入りされた日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :favorite_start_date, params[:favorite_start_date]
+      | 〜
+      = date_field_tag :favorite_end_date, params[:favorite_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | ユーザーID
+        th
+          | 氏名
+        th
+          | お気に入り数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["user_id"], admin_user_path(id: row["user_id"])
+            td
+              = row["full_name"]
+            td
+              = row["favorite_count"]

--- a/app/views/admin/dashboard/ranking/users/favoriting_words.html.slim
+++ b/app/views/admin/dashboard/ranking/users/favoriting_words.html.slim
@@ -1,0 +1,47 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入りしている言葉の多いユーザー
+
+  .panel-body
+    = render partial: "admin/dashboard/ranking/users/ranking_menu"
+
+    h5
+      | 「言葉の投稿日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :word_start_date, params[:word_start_date]
+      | 〜
+      = date_field_tag :word_end_date, params[:word_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    h5
+      | 「お気に入りした日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :favorite_start_date, params[:favorite_start_date]
+      | 〜
+      = date_field_tag :favorite_end_date, params[:favorite_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | ユーザーID
+        th
+          | 氏名
+        th
+          | お気に入り数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["user_id"], admin_user_path(id: row["user_id"])
+            td
+              = row["full_name"]
+            td
+              = row["favorite_count"]

--- a/app/views/admin/dashboard/ranking/users/followed.html.slim
+++ b/app/views/admin/dashboard/ranking/users/followed.html.slim
@@ -1,0 +1,47 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入りされている言葉の多いユーザー
+
+  .panel-body
+    = render partial: "admin/dashboard/ranking/users/ranking_menu"
+
+    h5
+      | 「ユーザーの登録日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :user_start_date, params[:user_start_date]
+      | 〜
+      = date_field_tag :user_end_date, params[:user_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    h5
+      | 「フォローされた日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :followed_start_date, params[:followed_start_date]
+      | 〜
+      = date_field_tag :followed_end_date, params[:followed_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | ユーザーID
+        th
+          | 氏名
+        th
+          | フォロワー数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["user_id"], admin_user_path(id: row["user_id"])
+            td
+              = row["full_name"]
+            td
+              = row["followed_count"]

--- a/app/views/admin/dashboard/ranking/users/following.html.slim
+++ b/app/views/admin/dashboard/ranking/users/following.html.slim
@@ -1,0 +1,47 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入りされている言葉の多いユーザー
+
+  .panel-body
+    = render partial: "admin/dashboard/ranking/users/ranking_menu"
+
+    h5
+      | 「ユーザーの登録日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :user_start_date, params[:user_start_date]
+      | 〜
+      = date_field_tag :user_end_date, params[:user_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    h5
+      | 「フォローした日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :follow_start_date, params[:follow_start_date]
+      | 〜
+      = date_field_tag :follow_end_date, params[:follow_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | ユーザーID
+        th
+          | 氏名
+        th
+          | フォロー数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["user_id"], admin_user_path(id: row["user_id"])
+            td
+              = row["full_name"]
+            td
+              = row["follow_count"]

--- a/app/views/admin/dashboard/ranking/users/posted_words.html.slim
+++ b/app/views/admin/dashboard/ranking/users/posted_words.html.slim
@@ -1,0 +1,46 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> 投稿数の多いユーザー
+
+  .panel-body
+    = render partial: "admin/dashboard/ranking/users/ranking_menu"
+
+    h5
+      | 「ユーザーの登録日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :user_start_date, params[:user_start_date]
+      | 〜
+      = date_field_tag :user_end_date, params[:user_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+    h5
+      | 「言葉の投稿日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :word_start_date, params[:word_start_date]
+      | 〜
+      = date_field_tag :word_end_date, params[:word_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | ユーザーID
+        th
+          | 氏名
+        th
+          | 投稿数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["user_id"], admin_user_path(id: row["user_id"])
+            td
+              = row["full_name"]
+            td
+              = row["word_count"]

--- a/app/views/admin/dashboard/ranking/words/favorited.html.slim
+++ b/app/views/admin/dashboard/ranking/words/favorited.html.slim
@@ -1,0 +1,53 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入りされている数の多い言葉
+
+  .panel-body
+    h5
+      | 「ユーザーの登録日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :user_start_date, params[:user_start_date]
+      | 〜
+      = date_field_tag :user_end_date, params[:user_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    h5
+      | 「フォローされた日」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :word_start_date, params[:word_start_date]
+      | 〜
+      = date_field_tag :word_end_date, params[:word_end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新"
+
+    table.table.table-striped
+      thead
+        th
+          | 順位
+        th
+          | 言葉ID
+        th
+          | 言葉
+        th
+          | 意味
+        th
+          | 投稿者
+        th
+          | お気に入り数
+      tbody
+        - @rows.each_with_index do |row, i|
+          tr
+            td
+              = i + 1
+            td
+              = link_to row["word_id"], admin_word_path(id: row["word_id"])
+            td
+              = row["word_name"]
+            td width="300"
+              = truncate row["word_description"], length: 20
+            td
+              = row["full_name"]
+            td
+              = row["favorite_count"]

--- a/app/views/admin/dashboard/transition/_transition_menu.html.slim
+++ b/app/views/admin/dashboard/transition/_transition_menu.html.slim
@@ -1,0 +1,26 @@
+h5
+  | 推移
+
+= link_to "お気に入り数の推移", \
+  favorite_admin_dashboard_transition_favorites_path(start_date: params[:start_date], end_date: params[:end_date]), \
+  class: "btn btn-sm"
+
+| &nbsp;
+
+= link_to "フォロー数の推移", \
+  follow_admin_dashboard_transition_follows_path(start_date: params[:start_date], end_date: params[:end_date]), \
+  class: "btn btn-sm"
+
+| &nbsp;
+
+= link_to "ユーザーの登録数の推移", \
+  registered_admin_dashboard_transition_users_path(start_date: params[:start_date], end_date: params[:end_date]), \
+  class: "btn btn-sm"
+
+| &nbsp;
+
+= link_to "言葉の投稿数の推移", \
+  posted_admin_dashboard_transition_words_path(start_date: params[:start_date], end_date: params[:end_date]), \
+  class: "btn btn-sm"
+
+hr

--- a/app/views/admin/dashboard/transition/favorites/favorite.html.slim
+++ b/app/views/admin/dashboard/transition/favorites/favorite.html.slim
@@ -1,0 +1,39 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> お気に入り数の推移
+
+  .panel-body
+    = render partial: "admin/dashboard/transition/transition_menu"
+
+    h5
+      | 「日付」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :start_date, params[:start_date]
+      | 〜
+      = date_field_tag :end_date, params[:end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新", class: "btn btn-default"
+
+    - if @daily_counts.present?
+      canvas#chart data-amounts=@daily_counts.to_json
+
+      table.table.table-striped
+        thead
+          th
+            | 日付
+          th
+            | お気に入り数
+        tbody
+          - @daily_counts.each do |date, count|
+            tr
+              td
+                = date
+              td
+                = count
+    - else
+      h4.text-center
+        | データが存在しません。
+
+- if @daily_counts.present?
+  = javascript_pack_tag "admin/dashboard/favorites/favorite"

--- a/app/views/admin/dashboard/transition/follows/follow.html.slim
+++ b/app/views/admin/dashboard/transition/follows/follow.html.slim
@@ -1,0 +1,39 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> フォロー数の推移
+
+  .panel-body
+    = render partial: "admin/dashboard/transition/transition_menu"
+
+    h5
+      | 「日付」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :start_date, params[:start_date]
+      | 〜
+      = date_field_tag :end_date, params[:end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新", class: "btn btn-default"
+
+    - if @daily_counts.present?
+      canvas#chart data-amounts=@daily_counts.to_json
+
+      table.table.table-striped
+        thead
+          th
+            | 日付
+          th
+            | フォロー数
+        tbody
+          - @daily_counts.each do |date, count|
+            tr
+              td
+                = date
+              td
+                = count
+    - else
+      h4.text-center
+        | データが存在しません。
+
+- if @daily_counts.present?
+  = javascript_pack_tag "admin/dashboard/follows/follow"

--- a/app/views/admin/dashboard/transition/users/registered.html.slim
+++ b/app/views/admin/dashboard/transition/users/registered.html.slim
@@ -1,0 +1,39 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> ユーザーの登録数の推移
+
+  .panel-body
+    = render partial: "admin/dashboard/transition/transition_menu"
+
+    h5
+      | 「日付」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :start_date, params[:start_date]
+      | 〜
+      = date_field_tag :end_date, params[:end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新", class: "btn btn-default"
+
+    - if @daily_counts.present?
+      canvas#chart data-amounts=@daily_counts.to_json
+
+      table.table.table-striped
+        thead
+          th
+            | 日付
+          th
+            | 登録数
+        tbody
+          - @daily_counts.each do |date, count|
+            tr
+              td
+                = date
+              td
+                = count
+    - else
+      h4.text-center
+        | データが存在しません。
+
+- if @daily_counts.present?
+  = javascript_pack_tag "admin/dashboard/users/registered"

--- a/app/views/admin/dashboard/transition/words/posted.html.slim
+++ b/app/views/admin/dashboard/transition/words/posted.html.slim
@@ -1,0 +1,39 @@
+.panel.panel-default
+  .panel-heading
+    = link_to "ダッシュボード", admin_dashboard_path
+    | &nbsp;> 言葉の投稿数の推移
+
+  .panel-body
+    = render partial: "admin/dashboard/transition/transition_menu"
+
+    h5
+      | 「日付」で絞り込み
+    = form_tag nil, method: :get
+      = date_field_tag :start_date, params[:start_date]
+      | 〜
+      = date_field_tag :end_date, params[:end_date]
+      | &nbsp;&nbsp;
+      = submit_tag "更新", class: "btn btn-default"
+
+    - if @daily_counts.present?
+      canvas#chart data-amounts=@daily_counts.to_json
+
+      table.table.table-striped
+        thead
+          th
+            | 日付
+          th
+            | 投稿数
+        tbody
+          - @daily_counts.each do |date, count|
+            tr
+              td
+                = date
+              td
+                = count
+    - else
+      h4.text-center
+        | データが存在しません。
+
+- if @daily_counts.present?
+  = javascript_pack_tag "admin/dashboard/words/posted"

--- a/app/views/admin/dashboards/show.html.slim
+++ b/app/views/admin/dashboards/show.html.slim
@@ -29,3 +29,23 @@
           .panel-body.text-right
             span.h3
               = separate_comma @favorites_count
+
+    h4
+      | 言葉ランキング
+    = link_to "お気に入りされている数の多い言葉", favorited_admin_dashboard_ranking_words_path, class: "btn btn-sm"
+
+    h4
+      | ユーザーランキング
+
+    = link_to "お気に入りされている言葉の多いユーザー", favorited_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+    = link_to "お気に入りしている言葉の多いユーザー", favoriting_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+    = link_to "投稿数の多いユーザー", posted_words_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+    = link_to "フォロワー数の多いユーザー", followed_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+    = link_to "フォロー数の多いユーザー", following_admin_dashboard_ranking_users_path, class: "btn btn-sm"
+
+    h4
+      | 推移
+    = link_to "お気に入り数の推移", favorite_admin_dashboard_transition_favorites_path, class: "btn btn-sm"
+    = link_to "フォロー数の推移", follow_admin_dashboard_transition_follows_path, class: "btn btn-sm"
+    = link_to "ユーザーの登録数の推移", registered_admin_dashboard_transition_users_path, class: "btn btn-sm"
+    = link_to "言葉の投稿数の推移", posted_admin_dashboard_transition_words_path, class: "btn btn-sm"

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 module Rediction
+  RELEASE_DATE = "2018-09-05".to_date.freeze
+
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -10,6 +10,52 @@ namespace :admin do
   resource :dashboard, only: %i[show]
   resources :words, only: %i[index show destroy]
 
+  namespace :dashboard do
+    namespace :ranking do
+      resources :users, only: %i[] do
+        collection do
+          get :favorited_words
+          get :favoriting_words
+          get :posted_words
+          get :followed
+          get :following
+        end
+      end
+
+      resources :words, only: %i[] do
+        collection do
+          get :favorited
+        end
+      end
+    end
+
+    namespace :transition do
+      resources :favorites, only: %i[] do
+        collection do
+          get :favorite
+        end
+      end
+
+      resources :follows, only: %i[] do
+        collection do
+          get :follow
+        end
+      end
+
+      resources :users, only: %i[] do
+        collection do
+          get :registered
+        end
+      end
+
+      resources :words, only: %i[] do
+        collection do
+          get :posted
+        end
+      end
+    end
+  end
+
   namespace :user, as: "users" do
     namespace :resignation do
       resources :requests, only: %i[index]

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   },
   "dependencies": {
     "@rails/webpacker": "3.5",
+    "@types/chart.js": "^2.7.32",
     "@types/jquery": "^3.3.6",
     "@types/react": "^16.4.11",
     "@types/react-dom": "^16.0.7",
     "axios": "^0.18.0",
     "babel-preset-react": "^6.24.1",
+    "chart.js": "^2.7.2",
     "jquery": "^3.3.1",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",

--- a/spec/controllers/admin/dashboard/ranking/users_controller.rb
+++ b/spec/controllers/admin/dashboard/ranking/users_controller.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Ranking::UsersController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #favorited_words" do
+    subject { get :favorited_words }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+
+  describe "GET #favoriting_words" do
+    subject { get :favoriting_words }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+
+  describe "GET #posted_words" do
+    subject { get :posted_words }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+
+  describe "GET #followed" do
+    subject { get :followed }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+
+  describe "GET #following" do
+    subject { get :following }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/dashboard/ranking/words_controller.rb
+++ b/spec/controllers/admin/dashboard/ranking/words_controller.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Ranking::WordsController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #favorited" do
+    subject { get :favorited }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/dashboard/transition/favorites_controller.rb
+++ b/spec/controllers/admin/dashboard/transition/favorites_controller.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Transition::FavoritesController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #favorite" do
+    subject { get :favorite }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/dashboard/transition/follows_controller.rb
+++ b/spec/controllers/admin/dashboard/transition/follows_controller.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Transition::FollowsController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #follow" do
+    subject { get :follow }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/dashboard/transition/users_controller.rb
+++ b/spec/controllers/admin/dashboard/transition/users_controller.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Transition::UsersController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #registered" do
+    subject { get :registered }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/dashboard/transition/words_controller.rb
+++ b/spec/controllers/admin/dashboard/transition/words_controller.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Admin::Dashboard::Transition::WordsController, type: :controller do
+  include_context 'current_admin_userとしてログイン後にアクセスする'
+
+  describe "GET #posted" do
+    subject { get :posted }
+    before { subject }
+
+    context "平常時アクセスの場合" do
+      it "HTTP 200 OK", :aggregate_failures do
+        expect(response).to have_http_status 200
+        expect(response).to render_template :show
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 管理画面で見れるようにしたデータ
- 言葉ランキング
  - お気に入りされている数の多い言葉

- ユーザーランキング
  - お気に入りされている言葉の多いユーザー
  - お気に入りしている言葉の多いユーザー
  - 投稿数の多いユーザー
  - フォロワー数の多いユーザー
  - フォロー数の多いユーザー

- 推移
  - お気に入り数の推移
  - フォロー数の推移
  - ユーザーの登録数の推移
  - 言葉の投稿数の推移


### 備考
Admin画面でしか使わないような特殊ロジックが多かったので、
そこはModelには切り出さずにAdmin用のModuleとしてControllerのconcernsに切り出しています。

### 画像
|ランキング|推移|
|--|--|
|![default](https://user-images.githubusercontent.com/25111231/45267830-c9568580-b4ae-11e8-9bbe-171156d1043b.png)|![default](https://user-images.githubusercontent.com/25111231/45267831-c9ef1c00-b4ae-11e8-83da-49960cd25689.png)|