### PR TITLE
logrageでLTSV形式のアクションログを収集するように実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,10 @@ gem "activerecord-import"
 gem 'rack-rewrite'
 # IPアドレス閲覧制限をおこなえるようにするもの
 gem 'rack-attack'
+# ログをより見やすくしてくれるもの(ユーザーIDなど好きな項目を簡易的にログに残せる)
+gem 'lograge'
+# Logstashに合うアウトップができるようにするもの
+gem 'logstash-event'
 
 ##
 # 管理画面用

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,12 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -236,6 +242,8 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.5.0)
       redis (>= 2.2, < 5)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rollbar (2.16.4)
       multi_json
     rspec (3.7.0)
@@ -354,6 +362,8 @@ DEPENDENCIES
   letter_opener
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
+  lograge
+  logstash-event
   meowcop
   migration_comments
   mysql2

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -23,6 +23,13 @@ class Admin::ApplicationController < ActionController::Base
     result.to_hash
   end
 
+  # lograge用のメソッド
+  # user_idはAPI, Adminなどで取得方法が異なるため、Controllerごとにpayloadに格納している。
+  def append_info_to_payload(payload)
+    super
+    payload[:user_id] = current_admin_user&.id
+  end
+
   private
 
   # 管理者用の認証処理

--- a/app/controllers/api/secure_application_controller.rb
+++ b/app/controllers/api/secure_application_controller.rb
@@ -1,6 +1,13 @@
 class Api::SecureApplicationController < ActionController::Base
   before_action :authenticate
 
+  # lograge用のメソッド
+  # user_idはAPI, Adminなどで取得方法が異なるため、Controllerごとにpayloadに格納している。
+  def append_info_to_payload(payload)
+    super
+    payload[:user_id] = session[:user_id]
+  end
+
   private
 
   # ユーザー認証を行うメソッド

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,13 @@ class ApplicationController < ActionController::Base
     redirect_to index_scoped_follow_users_words_path
   end
 
+  # lograge用のメソッド
+  # user_idはAPI, Adminなどで取得方法が異なるため、Controllerごとにpayloadに格納している。
+  def append_info_to_payload(payload)
+    super
+    payload[:user_id] = current_user&.id
+  end
+
   private
 
   # Basic認証

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  config.service_host = ENV['SERVICE_DOMAIN'] || "https://rediction-prod.herokuapp.com"
+  config.service_host = ENV['SERVICE_DOMAIN'] || "rediction.jp"
   # アプリケーションのホスト情報をmailer内で使用する際にそれをグローバルで利用できるようにするもの
   config.action_mailer.default_url_options = { host: config.service_host }
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,38 @@
+Rails.application.configure do
+  path = "#{Rails.root}/log/lograge_#{Rails.env}.log"
+  config.lograge.logger = ActiveSupport::Logger.new(path)
+  config.lograge.enabled = true
+  config.lograge.keep_original_rails_log = true
+  config.lograge.formatter = Lograge::Formatters::LTSV.new
+  config.lograge.base_controller_class = "::ApplicationController"
+
+  # user_id以外のrequest情報を格納している。
+  # user_idは継承元のControllerによって取得方法が異なるので、
+  # 各継承元のControllerで個別にpayloadに格納するように実装している。
+  config.lograge.custom_payload do |controller|
+    {
+      host: controller.request.host,
+      ip: controller.request.remote_ip,
+      referer: controller.request.referer,
+      user_agent: controller.request.user_agent
+    }
+  end
+
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w(controller action format authenticity_token)
+    data = {
+      level: 'info',
+      user_id: event.payload[:user_id],
+      time: event.time,
+      params: event.payload[:params].except(*exceptions)
+    }
+
+    if event.payload[:exception]
+      data[:level] = 'fatal'
+      data[:exception] = event.payload[:exception]
+      data[:exception_backtrace] = event.payload[:exception_object].backtrace[0..6]
+    end
+
+    data
+  end
+end


### PR DESCRIPTION
## ログ収集に利用したライブラリ
### gem
**lograge**

### url
https://github.com/roidrage/lograge

### 説明
今回の要件だったuser_idを含んだログを収集可能で、リポジトリの更新も活発的だった上、利用率も高かったため、今回の導入を決めた。
ログの形式はjsonかltsvかで迷う部分はあったが、今回はファイルの容量が少ないメリットを取りltsv形式でログ収集するように実装してある。