### PR TITLE
お気に入り件数を表示するように改修

### DIFF
--- a/app/assets/stylesheets/templates/words/show.scss
+++ b/app/assets/stylesheets/templates/words/show.scss
@@ -49,34 +49,46 @@
       }
     }
 
-    &-favorite {
-      &.active {
-        .show-word-sub-favorite-icon {
+    &-action {
+      display: flex;
+      align-items: center;
+
+      &-favorite {
+        &.active {
+          .show-word-sub-action-favorite-icon {
+            &.favorite {
+              display: block;
+            }
+
+            &.unfavorite {
+              display: none;
+            }
+          }
+        }
+
+        &-icon {
+          cursor: pointer;
+          width: 30px;
+
           &.favorite {
-            display: block;
-          }
-
-          &.unfavorite {
             display: none;
+            margin-bottom: 2px;
           }
         }
       }
 
-      &-icon {
-        cursor: pointer;
-        width: 30px;
-
-        &.favorite {
-          display: none;
-          margin-bottom: 2px;
-        }
+      &-favorite-count {
+        width: 28px;
+        font-size: 13px;
+        text-align: right;
+        color: $secondaryColor;
       }
-    }
 
-    &-trash-icon {
-      cursor: pointer;
-      color: $wordTrashIconColor;
-      font-size: 24px;
+      &-trash-icon {
+        cursor: pointer;
+        color: $wordTrashIconColor;
+        font-size: 24px;
+      }
     }
   }
 }

--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -3,5 +3,8 @@ class Api::FavoritesController < Api::SecureApplicationController
 
   def update
     @favorite = Favorite.toggle_status!(word_id: params[:word_id], user_id: params[:user_id])
+
+    # wordのお気に入り件数
+    @favorite_count = Favorite.where(word_id: params[:word_id]).count
   end
 end

--- a/app/controllers/words_controller.rb
+++ b/app/controllers/words_controller.rb
@@ -30,7 +30,7 @@ class WordsController < ApplicationController
   end
 
   def show
-    @word = Word.find(params[:id]);
+    @word = Word.find(params[:id])
   end
 
   def destroy

--- a/app/javascript/packs/words/show.ts
+++ b/app/javascript/packs/words/show.ts
@@ -1,5 +1,11 @@
+// Word#showはReactに起き変えていないため、現状JS処理もjQuery主体になっている。
+// 可読性が著しく下がる前にReactに全体を置き換えること。
+
 import $ from "jquery";
-import FavoriteHandler from "../../providers/FavoriteHandler";
+import FavoriteHandler, {
+  FavoriteHandlerResponse
+} from "../../providers/FavoriteHandler";
+import NumberFormatter from "../../providers/Formatter/NumberFormatter";
 
 const wordId = $("#show-word").data("word-id");
 const currentUserId = $("#show-word").data("current-user-id");
@@ -9,32 +15,53 @@ const favoriteHandler: FavoriteHandler = new FavoriteHandler(
   currentUserId
 );
 
+const ACTION_FAVORITE_ELM = "#show-word-sub-action-favorite";
+const ACTION_FAVORITE_COUNT_ELM = "#show-word-sub-action-favorite-count";
+
+// お気に入り件数の表記を更新
+const updateFavoriteCountNotation = (count: number): void => {
+  const countNotation: string =
+    count !== 0 ? NumberFormatter.separateByComma(count) : "";
+  $(ACTION_FAVORITE_COUNT_ELM).text(countNotation);
+};
+
+// お気に入りステータス用の事前更新処理
+const advanceUpdateForToggleFavoriteStatus = () => {
+  const currentFavoriteCount = Number($(ACTION_FAVORITE_COUNT_ELM).text());
+
+  const advanceFavoriteCount = $(ACTION_FAVORITE_ELM).hasClass("active")
+    ? currentFavoriteCount - 1
+    : currentFavoriteCount + 1;
+
+  updateFavoriteCountNotation(advanceFavoriteCount);
+  $(ACTION_FAVORITE_ELM).toggleClass("active");
+};
+
 const toggleFavoriteStatus = async () => {
   // API通信が完了する前に見た目上だけ切り替える。
-  $("#show-word-sub-favorite").toggleClass("active");
+  advanceUpdateForToggleFavoriteStatus();
 
-  const favoriteId:
-    | number
-    | boolean
-    | null = await favoriteHandler.toggleFavoriteStatus();
+  const favoriteHandlerResponse: FavoriteHandlerResponse | null = await favoriteHandler.toggleFavoriteStatus();
 
-  // falseが返された時は処理を中断
-  if (favoriteId === false) {
+  // nullが返された時は処理を中断
+  if (favoriteHandlerResponse === null) {
     return;
   }
 
-  if (favoriteId) {
-    $("#show-word-sub-favorite").addClass("active");
+  if (favoriteHandlerResponse.favorited) {
+    $(ACTION_FAVORITE_ELM).addClass("active");
   } else {
-    $("#show-word-sub-favorite").removeClass("active");
+    $(ACTION_FAVORITE_ELM).removeClass("active");
   }
+
+  updateFavoriteCountNotation(favoriteHandlerResponse.favorite_count);
 };
 
-$(document).on("click", "#show-word-sub-favorite", toggleFavoriteStatus);
+$(document).on("click", ACTION_FAVORITE_ELM, toggleFavoriteStatus);
 
 /*---- ここから、言葉削除用のモーダル処理 -----*/
 
-$(document).on("click", "#show-word-sub-trash-icon", () => {
+$(document).on("click", "#show-word-sub-action-trash-icon", () => {
   $("#modal-simple-confirm").addClass("active");
 });
 

--- a/app/javascript/providers/FavoriteHandler.ts
+++ b/app/javascript/providers/FavoriteHandler.ts
@@ -1,7 +1,12 @@
 import BaseFetcher, { BaseFetcherInterface } from "./BaseFetcher";
 
 interface FavoriteHandlerInterface extends BaseFetcherInterface {
-  toggleFavoriteStatus(): Promise<boolean | null>;
+  toggleFavoriteStatus(): Promise<FavoriteHandlerResponse | null>;
+}
+
+export interface FavoriteHandlerResponse {
+  favorited: boolean;
+  favorite_count: number;
 }
 
 class FavoriteHandler extends BaseFetcher implements FavoriteHandlerInterface {
@@ -19,14 +24,13 @@ class FavoriteHandler extends BaseFetcher implements FavoriteHandlerInterface {
     // リクエスト開始
     this.startRequest();
 
-    // 言葉リストを取得
-    const responseData = await this.patch();
-    const favorited: boolean = responseData.favorited;
+    // お気に入りステータスの更新
+    const responseData: FavoriteHandlerResponse = await this.patch();
 
     // リクエスト終了
     this.endRequest();
 
-    return favorited;
+    return responseData;
   }
 }
 

--- a/app/javascript/providers/Formatter/NumberFormatter.ts
+++ b/app/javascript/providers/Formatter/NumberFormatter.ts
@@ -1,0 +1,6 @@
+export default {
+  // 数値を3桁おきにカンマで区切る処理
+  separateByComma: (num: number): string => {
+    return String(num).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");
+  }
+};

--- a/app/javascript/providers/Word/FetchedWordInterface.ts
+++ b/app/javascript/providers/Word/FetchedWordInterface.ts
@@ -5,6 +5,7 @@ interface FetchedWord {
   phonetic: string;
   description: string;
   favorited: boolean;
+  favorite_count: number;
   profile: Profile;
 }
 

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -34,5 +34,14 @@ class Favorite < ApplicationRecord
     def extract_favorite_word_ids(words:, user_id:)
       where(word_id: words.map(&:id), user_id: user_id).map(&:word_id)
     end
+
+    # words(複数)のお気に入り件数をハッシュ形式で返却
+    # ハッシュの形式 : { word_id => お気に入り数 }
+    def favorite_counts_hash(words)
+      select("word_id").select("count(word_id) as favorite_count")
+                       .where(word_id: words.map(&:id))
+                       .group(:word_id)
+                       .reduce(Hash.new) { |sum, v| sum.merge(v.word_id => v.favorite_count) }
+    end
   end
 end

--- a/app/views/api/favorites/update.json.jbuilder
+++ b/app/views/api/favorites/update.json.jbuilder
@@ -1,1 +1,2 @@
 json.favorited @favorite.present?
+json.favorite_count @favorite_count

--- a/app/views/api/words/_index_base.json.jbuilder
+++ b/app/views/api/words/_index_base.json.jbuilder
@@ -4,6 +4,9 @@ json.words(words) do |word|
   # ログイン中のユーザーがwordをお気に入り登録中かどうかを示すフラグ
   json.favorited @favorite_word_ids.include?(word.id)
 
+  # wordのお気に入り数
+  json.favorite_count @faborite_counts[word.id] || 0
+
   json.profile do
     if word.user.profile.present?
       json.partial! "api/partials/user/profile", locals: {profile: word.user.profile}

--- a/app/views/words/show.html.slim
+++ b/app/views/words/show.html.slim
@@ -33,12 +33,16 @@ ruby:
           p
             = @word.user.profile.job
 
-    - if current_user.id == @word.user_id
-      i.fas.fa-trash-alt#show-word-sub-trash-icon.show-word-sub-trash-icon
-    - else
-      #show-word-sub-favorite.show-word-sub-favorite class=(current_user.favorite_word?(@word) ? "active" : "")
-        = image_tag "favorite/favoriteIcon.svg", class: "show-word-sub-favorite-icon favorite"
-        = image_tag "favorite/unfavoriteIcon.svg", class: "show-word-sub-favorite-icon unfavorite"
+    .show-word-sub-action
+      - if current_user.id == @word.user_id
+        i.fas.fa-trash-alt#show-word-sub-action-trash-icon.show-word-sub-action-trash-icon
+      - else
+        #show-word-sub-action-favorite.show-word-sub-action-favorite class=(current_user.favorite_word?(@word) ? "active" : "")
+          = image_tag "favorite/favoriteIcon.svg", class: "show-word-sub-action-favorite-icon favorite"
+          = image_tag "favorite/unfavoriteIcon.svg", class: "show-word-sub-action-favorite-icon unfavorite"
+
+        #show-word-sub-action-favorite-count.show-word-sub-action-favorite-count
+          = @word.favorites.count != 0 ? @word.favorites.count.to_s(:delimited) : ""
 
 #modal-simple-confirm.modal-simple-confirm
   #modal-simple-confirm-cassette.modal-simple-confirm-cassette

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -94,5 +94,35 @@ RSpec.describe Favorite, type: :model do
         end
       end
     end
+
+    describe ".favorite_counts_hash" do
+      subject { Favorite.favorite_counts_hash(words) }
+      let(:words) { create_list(:word, 5) }
+      let(:result) { subject }
+
+      context "全てのwordのお気に入り件数が0件より多い場合" do
+        before { words.each { |word| create(:favorite, word: word) } }
+
+        it "全てのwordのお気に入り件数がハッシュ形式で返されること" do
+          expect(result.size).to eq words.size
+          expect(words.all? { |word| result[word.id] == 1 }).to eq true
+        end
+      end
+
+      context "1つのwordのお気に入り件数のみ0件より多い場合" do
+        before { create(:favorite, word: words.first) }
+
+        it "お気に入り件数の多いwordのお気に入り件数のみがハッシュ形式で返されること" do
+          expect(result.size).to eq 1
+          expect(result[words.first.id]).to eq 1
+        end
+      end
+
+      context "全てのwordのお気に入り件数が0件の場合" do
+        it "空のハッシュが返されること" do
+          expect(result.size).to eq 0
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/favorites_controller_spec.rb
+++ b/spec/requests/api/favorites_controller_spec.rb
@@ -22,6 +22,7 @@ describe Api::FavoritesController, type: :request do
       it "favoritedにfalseが格納されて返されること" do
         subject
         expect(JSON.parse(response.body)["favorited"]).to eq false
+        expect(JSON.parse(response.body)["favorite_count"]).to eq 0
       end
 
       it "changesテーブルのeventがdeleteとして登録されること" do
@@ -39,6 +40,7 @@ describe Api::FavoritesController, type: :request do
       it "favoritedにtrueが格納されて返されること" do
         subject
         expect(JSON.parse(response.body)["favorited"]).to eq true
+        expect(JSON.parse(response.body)["favorite_count"]).to eq 1
       end
 
       it "changesテーブルのeventがcreateとして登録されること" do


### PR DESCRIPTION
## 実装内容
1. 一覧でのお気に入り件数表示
2. 詳細でのお気に入り件数表示
3. 一覧でのお気に入りステータス更新時のお気に入り件数更新処理
4. 一覧でのお気に入りステータス更新時のお気に入り件数更新処理

## 備考
件数の文字がモックより少し太いのはフォントの問題で、
これ以上は細くできないので、スルーで問題ないです。
(これ以上細くしたいという依頼がある場合は、Rediction全体のフォントを変更して対応する予定)

## デザイン
### 一覧
|モック|実装|
|--|--|
|![2018-09-24 22 37 30](https://user-images.githubusercontent.com/25111231/45955414-c9c45400-c04a-11e8-84e5-84cc3963e099.png)|![default](https://user-images.githubusercontent.com/25111231/45955272-633f3600-c04a-11e8-93b6-a135e94adb37.png)|


### 詳細
|モック|実装|
|--|--|
|![2018-09-24 22 37 41](https://user-images.githubusercontent.com/25111231/45955304-7d791400-c04a-11e8-8dde-5919f0c3e459.png)|![2](https://user-images.githubusercontent.com/25111231/45955271-633f3600-c04a-11e8-9176-2bc36577bef6.png)|